### PR TITLE
Undo the name: key in user

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}


### PR DESCRIPTION
Why: email can serve as a container for name.
Client asks for "your name" & places it in email field.
Less work to go with this approach.

Closes #4